### PR TITLE
Add Godot ignores to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+
+# Godot-specific ignores
+.import/
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~
+
 # Logs and databases #
 ######################
 *.log
@@ -29,7 +45,6 @@ Thumbs.db
 
 # Etc
 .sconsign.dblite
-demo/.import/
 demo/build
 test_backup_new.json
 


### PR DESCRIPTION
The gitignore was missing a few things. For example, `.mono/` is generated if you open the project with a C#-enabled version of Godot (even if the project has no C# files).

There is no need to prefix with `demo/` since `.import/` ignores any folder anywhere named `.import` (to make it only for the repo's root directory, you would need a leading slash).