### PR TITLE
Add Legacy Linux Build for Ubuntu 16.04

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   linux-compilation:
-    name: Linux Compilation
+    name: Ubuntu 20.04 Compilation
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout
@@ -59,4 +59,53 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: x11
+          path: ${{env.PROJECT_FOLDER}}/${{env.TARGET_PATH}}
+  linux-legacy-compilation:
+    name: Ubuntu 16.04 Compilation
+    runs-on: "ubuntu-16.04"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+          submodules: recursive
+
+      # Install all packages (except scons)
+      - name: Configure dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      # Linux shared libraries are humongous (>70MB) for some reason.. don't forget to strip them!
+      - name: Compilation
+        run: |
+          mkdir -v -p ${{env.PROJECT_FOLDER}}/${{env.TARGET_PATH}}
+          cd ${{env.PROJECT_FOLDER}}
+          cd godot-cpp
+          scons platform=linux bits=64 target=${{env.TARGET}} generate_bindings=yes -j4
+          cd ..
+          scons platform=linux target=${{env.TARGET}} target_path=${{env.TARGET_PATH}} target_name=${{env.TARGET_NAME}}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: x11-legacy
           path: ${{env.PROJECT_FOLDER}}/${{env.TARGET_PATH}}


### PR DESCRIPTION
This legacy build can be usefule for devs who use older versions on Linux.

Closes: #36 