### PR TITLE
Handle unicode text

### DIFF
--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -129,7 +129,7 @@ bool SQLite::open_db()
 
     if (rc != SQLITE_OK)
     {
-        UtilityFunctions::printerr("GDSQLite Error: Can't open database: " + String(sqlite3_errmsg(db)));
+        UtilityFunctions::printerr("GDSQLite Error: Can't open database: " + String::utf8(sqlite3_errmsg(db)));
         return false;
     }
     else if (verbosity_level > VerbosityLevel::QUIET)
@@ -143,7 +143,7 @@ bool SQLite::open_db()
         rc = sqlite3_exec(db, "PRAGMA foreign_keys=on;", NULL, NULL, &zErrMsg);
         if (rc != SQLITE_OK)
         {
-            UtilityFunctions::printerr("GDSQLite Error: Can't enable foreign keys: " + String(zErrMsg));
+            UtilityFunctions::printerr("GDSQLite Error: Can't enable foreign keys: " + String::utf8(zErrMsg));
             sqlite3_free(zErrMsg);
             return false;
         }
@@ -198,7 +198,7 @@ bool SQLite::query_with_bindings(const String &p_query, Array param_bindings)
     /* Prepare an SQL statement */
     rc = sqlite3_prepare_v2(db, sql, -1, &stmt, &pzTail);
     zErrMsg = sqlite3_errmsg(db);
-    error_message = String(zErrMsg);
+    error_message = String::utf8(zErrMsg);
     if (rc != SQLITE_OK)
     {
         UtilityFunctions::printerr(" --> SQL error: " + error_message);
@@ -261,7 +261,7 @@ bool SQLite::query_with_bindings(const String &p_query, Array param_bindings)
     if (verbosity_level > VerbosityLevel::NORMAL)
     {
         char *expanded_sql = sqlite3_expanded_sql(stmt);
-        UtilityFunctions::print(expanded_sql);
+        UtilityFunctions::print(String::utf8(expanded_sql));
         sqlite3_free(expanded_sql);
     }
 
@@ -287,7 +287,7 @@ bool SQLite::query_with_bindings(const String &p_query, Array param_bindings)
                 break;
 
             case SQLITE_TEXT:
-                column_value = Variant((char *)sqlite3_column_text(stmt, i));
+                column_value = Variant(String::utf8((char *)sqlite3_column_text(stmt, i)));
                 break;
 
             case SQLITE_BLOB:
@@ -308,7 +308,7 @@ bool SQLite::query_with_bindings(const String &p_query, Array param_bindings)
             }
 
             const char *azColName = sqlite3_column_name(stmt, i);
-            column_dict[String(azColName)] = column_value;
+            column_dict[String::utf8(azColName)] = column_value;
         }
         /* Add result to query_result Array */
         query_result.append(column_dict);
@@ -319,7 +319,7 @@ bool SQLite::query_with_bindings(const String &p_query, Array param_bindings)
 
     rc = sqlite3_errcode(db);
     zErrMsg = sqlite3_errmsg(db);
-    error_message = String(zErrMsg);
+    error_message = String::utf8(zErrMsg);
     if (rc != SQLITE_OK)
     {
         UtilityFunctions::printerr(" --> SQL error: " + error_message);
@@ -624,7 +624,7 @@ bool SQLite::import_from_json(String import_path)
     std::stringstream buffer;
     buffer << ifs.rdbuf();
     std::string str = buffer.str();
-    String json_string = String(str.c_str());
+    String json_string = String::utf8(str.c_str());
     ifs.close();
 
     /* Attempt to parse the result and, if unsuccessful, throw a parse error specifying the erroneous line */


### PR DESCRIPTION
This should fix #87.

I have tested the following cases on Windows:

- Unicode database values works. 
- Unicode database column names works.
- `import_from_json` and `export_to_json` with Unicode column names and values work.
- Console in Godot now prints the correct Unicode characters.

*Note: `import_from_json` and `export_to_json` won't work with non-ASCII file paths on Windows. It is the expected behavior since we are using ifstream/ofstream directly. I notice that `open_db` could work with the non-ASCII file path, probably because `sqlite3_open_v2` handles the file path for us. It seems that there is no easy solution for Unicode path handling on Windows.*

![image](https://user-images.githubusercontent.com/22541353/189564654-70a91eb0-fad6-4032-a911-2a676873d343.png)