### PR TITLE
Enable the use of shared in-memory databases

### DIFF
--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -85,7 +85,7 @@ bool SQLite::open_db()
 {
     char *zErrMsg = 0;
     int rc;
-    if (path != ":memory:")
+    if (path.find(":memory:") == -1)
     {
         /* Add the default_extension to the database path if no extension is present */
         /* Skip if the default_extension is an empty string to allow for paths without extension */
@@ -110,7 +110,7 @@ bool SQLite::open_db()
     /* Try to open the database */
     if (read_only)
     {
-        if (path != ":memory:")
+        if (path.find(":memory:") == -1)
         {
             sqlite3_vfs_register(gdsqlite_vfs(), 0);
             rc = sqlite3_open_v2(char_path, &db, SQLITE_OPEN_READONLY, "godot");
@@ -123,7 +123,7 @@ bool SQLite::open_db()
     }
     else
     {
-        rc = sqlite3_open_v2(char_path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+        rc = sqlite3_open_v2(char_path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI, NULL);
         /* Identical to: `rc = sqlite3_open(char_path, &db);`*/
     }
 


### PR DESCRIPTION
I'm using a lot of threads in my game and prefer to use `:memory:` databases. 

To properly thread SQLite I needed more connections - which for `:memory:` you need to switch to a URI opener: `file::memory:?cache=shared`

This required three small changes in the add-on, including an additional flag to `sqlite3_open_v2`. I can't imagine this has any drawbacks for other use-cases so I kept the flag on by default. 