### PR TITLE
Update build system to beta3.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -7,8 +7,8 @@ target_name = ARGUMENTS.pop("target_name", "libgdsqlite")
 
 env = SConscript("godot-cpp/SConstruct")
 
-target = "{}{}.{}.{}".format(
-    target_path, target_name, env["platform"], env["target"]
+target = "{}{}".format(
+    target_path, target_name
 )
 
 # For the reference:
@@ -31,9 +31,9 @@ if env["platform"] == "macos":
         env["target"]
     )
 else:
-    target = "{}.{}{}".format(
+    target = "{}{}{}".format(
         target,
-        env["arch_suffix"],
+        env["suffix"],
         env["SHLIBSUFFIX"]
     )
 

--- a/demo/addons/godot-sqlite/gdsqlite.gdextension
+++ b/demo/addons/godot-sqlite/gdsqlite.gdextension
@@ -4,12 +4,12 @@ entry_symbol = "sqlite_library_init"
 
 [libraries]
 
-macos.debug = "res://addons/godot-sqlite/bin/libgdsqlite.macos.debug.framework"
-macos.release = "res://addons/godot-sqlite/bin/libgdsqlite.macos.release.framework"
-windows.debug.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.debug.x86_64.dll"
-windows.release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.release.x86_64.dll"
-linux.debug.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.debug.x86_64.so"
-linux.release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.release.x86_64.so"
+macos.debug = "res://addons/godot-sqlite/bin/libgdsqlite.macos.template_debug.framework"
+macos.release = "res://addons/godot-sqlite/bin/libgdsqlite.macos.template_release.framework"
+windows.debug.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.template_debug.x86_64.dll"
+windows.release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.template_release.x86_64.dll"
+linux.debug.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.template_debug.x86_64.so"
+linux.release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.template_release.x86_64.so"
 
 [dependencies]
 


### PR DESCRIPTION
Updates our Sconstruct to account for scons changes in godot-cpp. 

Could also change the logic to remove the new target names to match the old.