### PR TITLE
Check PACKED_BYTE_ARRAY size before trying to bind to parameter

### DIFF
--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -252,7 +252,11 @@ bool SQLite::query_with_bindings(const String &p_query, Array param_bindings)
         case Variant::PACKED_BYTE_ARRAY:
         {
             PackedByteArray binding = ((const PackedByteArray &)binding_value);
-            sqlite3_bind_blob64(stmt, i + 1, binding.ptr(), binding.size(), SQLITE_TRANSIENT);
+            if (binding.size() == 0) {
+                sqlite3_bind_null(stmt, i + 1);
+            } else {
+                sqlite3_bind_blob64(stmt, i + 1, binding.ptr(), binding.size(), SQLITE_TRANSIENT);
+            }
             break;
         }
 


### PR DESCRIPTION
Not sure if this is the right approach, but I have a nullable BLOB column in SQLite, and in GDScript I will pass a `PackedByteArray()` to avoid GDScript 2.0's stronger typing error. I figured an empty array would be OK, but it would throw an error on `sqlite3_bind_blob64` complaining about trying to grab the `0 p_index` when `->size() = 0`. 

This check avoids that error, but would fail on a not_null BLOB column when passed an empty array. I think that's OK because null is the likely the proper value to handle an empty variable being passed?