### PR TITLE
Mention "unique" column option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Additionally, a video tutorial by [Mitch McCollum (finepointcgi)](https://github
     **Optional fields**:
 
     - **"not_null"** *(default = false)*: Is the NULL value an invalid value for this column?
+    
+    - **"unique"** *(default = false)*: Does the column have a unique constraint?
 
     - **"default"**: The default value of the column if not explicitly given.
 


### PR DESCRIPTION
The "create_table" function can already accept the "unique" flag. However, it isn't mentioned in the README. Here I add it so users know it exists.