### PR TITLE
Add default value to select_rows columns array

### DIFF
--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -505,7 +505,7 @@ bool SQLite::insert_rows(String p_name, Array p_row_array)
     return true;
 }
 
-Array SQLite::select_rows(String p_name, String p_conditions, Array p_columns_array)
+Array SQLite::select_rows(String p_name, String p_conditions, Array p_columns_array = ["*"])
 {
     String query_string;
     /* Create SQL statement */


### PR DESCRIPTION
When selecting rows, it seems like a common usage is to just select all of them. However, sending in the value ["*"] is unintuitive and might not cross peoples mind.

Here I add a default value of ["*"] in the select_rows function so that the columns value can just be omitted to select all coulumns.