### PR TITLE
Update to beta 8 and update demo .gdextension.

### DIFF
--- a/demo/addons/godot-sqlite/gdsqlite.gdextension
+++ b/demo/addons/godot-sqlite/gdsqlite.gdextension
@@ -4,18 +4,18 @@ entry_symbol = "sqlite_library_init"
 
 [libraries]
 
-macos.debug = "res://addons/godot-sqlite/bin/libgdsqlite.macos.template_debug.framework"
-macos.release = "res://addons/godot-sqlite/bin/libgdsqlite.macos.template_release.framework"
-windows.debug.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.template_debug.x86_64.dll"
-windows.release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.template_release.x86_64.dll"
-linux.debug.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.template_debug.x86_64.so"
-linux.release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.template_release.x86_64.so"
+macos = "res://addons/godot-sqlite/bin/libgdsqlite.macos.template_debug.framework"
+macos.template_release = "res://addons/godot-sqlite/bin/libgdsqlite.macos.template_release.framework"
+windows.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.template_debug.x86_64.dll"
+windows.template_release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.windows.template_release.x86_64.dll"
+linux.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.template_debug.x86_64.so"
+linux.template_release.x86_64 = "res://addons/godot-sqlite/bin/libgdsqlite.linux.template_release.x86_64.so"
 
 [dependencies]
 
-macos.debug = {}
-macos.release = {}
-windows.debug.x86_64 = {}
-windows.release.x86_64 = {}
-linux.debug.x86_64 = {}
-linux.release.x86_64 = {}
+macos = {}
+macos.template_release = {}
+windows.x86_64 = {}
+windows.template_release.x86_64 = {}
+linux.x86_64 = {}
+linux.template_release.x86_64 = {}


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/67906 updates how gdextension libraries are expected to be named. I tried the new `autodetect_library_prefix ` but it's broken at the moment (loads fine in editor, won't load in export). 
