### PR TITLE
godot-cpp library filename fix in case if macos_arch parameter is used

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -385,10 +385,11 @@ env.Append(CPPPATH=[
 arch_suffix = env['bits']
 if env['platform'] == 'ios':
     arch_suffix = env['ios_arch']
-if env['platform'] == 'javascript':
+elif env['platform'] == 'javascript':
     arch_suffix = 'wasm'
-if env['macos_arch'] != 'universal':
-    arch_suffix = env['macos_arch']
+elif env['platform'] == 'osx':
+    if env['macos_arch'] != 'universal':
+        arch_suffix = env['macos_arch']
 
 cpp_bindings_libname = 'libgodot-cpp.{}.{}.{}'.format(
                         env['platform'],

--- a/SConstruct
+++ b/SConstruct
@@ -387,6 +387,8 @@ if env['platform'] == 'ios':
     arch_suffix = env['ios_arch']
 if env['platform'] == 'javascript':
     arch_suffix = 'wasm'
+if env['macos_arch'] != 'universal':
+    arch_suffix = env['macos_arch']
 
 cpp_bindings_libname = 'libgodot-cpp.{}.{}.{}'.format(
                         env['platform'],


### PR DESCRIPTION
Small fix for build script for case when macos_arch parameter is set to anything other than 'universal'
Otherwise godot-cpp library cannot be found and build fails.