### PR TITLE
Add support for multi-column primary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ Additionally, a video tutorial by [Mitch McCollum (finepointcgi)](https://github
     - **"default"**: The default value of the column if not explicitly given.
 
     - **"primary_key"** *(default = false)*: Is this the primary key of this table?  
-    Evidently, only a single column can be set as the primary key.
+    Multiple columns can be set as a primary key.
 
     - **"auto_increment"** *(default = false)*: Automatically increment this column when no explicit value is given. This auto-generated value will be one more (+1) than the largest value currently in use.
 
-        ***NOTE**: Auto-incrementing a column only works when this column is the primary key!*
+        ***NOTE**: Auto-incrementing a column only works when this column is the primary key and no other columns are primary keys!*
 
     - **"foreign_key"**: Enforce an "exist" relationship between tables by setting this variable to `foreign_table.foreign_column`. In other words, when adding an additional row, the column value should be an existing value as found in the column with name `foreign_column` of the table with name `foreign_table`.
 

--- a/doc_classes/SQLite.xml
+++ b/doc_classes/SQLite.xml
@@ -91,9 +91,9 @@
 				    * [i]Data types not found in this list throw an error and end up finalizing the current SQLite statement.[/i][br]    ** [i]with the question mark being replaced by the maximum amount of characters[/i]
 				[b]Optional fields[/b]:
 				- [b]"not_null"[/b] [i](default = false)[/i]: Is the NULL value an invalid value for this column?[br]- [b]"unique"[/b] [i](default = false)[/i]: Does the column have a unique constraint?[br]- [b]"default"[/b]: The default value of the column if not explicitly given.[br]- [b]"primary_key"[/b] [i](default = false)[/i]: Is this the primary key of this table?
-				    Evidently, only a single column can be set as the primary key.
+				    Multiple columns can be set as a primary key.
 				- [b]"auto_increment"[/b] [i](default = false)[/i]: Automatically increment this column when no explicit value is given. This auto-generated value will be one more (+1) than the largest value currently in use.
-				    [i][b]NOTE[/b]: Auto-incrementing a column only works when this column is the primary key![/i]
+				    [i][b]NOTE[/b]: Auto-incrementing a column only works when this column is the primary key and no other columns are primary keys![/i]
 				- [b]"foreign_key"[/b]: Enforce an "exist" relationship between tables by setting this variable to [code]foreign_table.foreign_column[/code]. In other words, when adding an additional row, the column value should be an existing value as found in the column with name [code]foreign_column[/code] of the table with name [code]foreign_table[/code].
 				    [i][b]NOTE[/b]: Availability of foreign keys has to be enabled by setting the [code]foreign_keys[/code]-variable to true BEFORE opening the database.[/i]
 				[b]Example usage[/b]:


### PR DESCRIPTION
This PR adds support for primary keys, that span over multiple columns.

Multi-column primary keys are supported by [SQLite](https://www.sqlite.org/lang_createtable.html) and also PostgreSQL, MariaDB and mysql.

SQLite however has [as restriction](https://www.sqlitetutorial.net/sqlite-primary-key/), that the table can't be altered after its creation to introduce a multi-column primary key.

While it's possible to create a "CREATE TABLE" SQL-statement in GDScript to achieve the goal, it would be beneficial to have direct support for this in godot-sqlite. Currently I'm working on a project, that relies on multi-column primary keys and my workaround is rather annoying.

The implementation is done in a way, that it doesn't break the API.

If this feature and approach is considered a reasonable addition for godot-sqlite, I will update the PR and make adjustments to the docs.

Implements part of #96.