### PR TITLE
Extension Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,34 @@ Additionally, a video tutorial by [Mitch McCollum (finepointcgi)](https://github
 
     Backup or restore the current database to/from a path, see [here](https://www.sqlite.org/backup.html). This feature is useful if you are using a database as your save file and you want to easily implement a saving/loading mechanic. Be warned that the original database will be overwritten entirely when restoring.
 
+- int enable_load_extension = **enable_load_extension(** Boolean onoff **)**
+
+    [Extension loading](https://www.sqlite.org/c3ref/load_extension.html) is disabled by default for security reasons. There are two ways to load an extension: C-API and SQL function. This method turns on both options.
+    SQL function `load_extension()` can only be used after enabling extension loading with this method. Preferably should be disabled after loading the extension to prevent SQL injections. Returns the SQLite return code.
+
+    ```gdscript
+    var module_path = ProjectSettings.globalize_path("res://addons/godot-sqlite/extensions/spellfix.dll")
+    db.enable_load_extension(true)
+    db.query_with_bindings(
+        "select load_extension(?, ?);", [
+            module_path,
+            "sqlite3_spellfix_init"
+        ])
+    db.enable_load_extension(false)
+    ```
+
+- int load_extension = **load_extension(** String extension_path, String extension_entry_point **)**
+
+    Loads the extension in the given path. Does not require `enable_load_extension()`, as it only enables C-API during the call and disables it right after, utilizing the recommended extension loading method declared by the SQLite documentation ([see](https://www.sqlite.org/c3ref/load_extension.html)). Returns the SQLite return code.
+    - **extension_path:** the path to the compiled binary of the extension
+    - **entrypoint:** the extension's entrypoint method (init function). It is defined in the .c file of the extension.
+
+   Example for loading the spellfix module:
+
+    ```gdscript
+    db.load_extension("res://addons/godot-sqlite/extensions/spellfix.dll", "sqlite3_spellfix_init")
+    ```
+
 ## Frequently Asked Questions (FAQ)
 
 ### 1. My query fails and returns syntax errors, what should I do?

--- a/doc_classes/SQLite.xml
+++ b/doc_classes/SQLite.xml
@@ -197,6 +197,36 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="enable_load_extension">
+			<return type="int" />
+			<description>
+				[url=https://www.sqlite.org/c3ref/load_extension.html]Extension loading[/url] is disabled by default for security reasons. There are two ways to load an extension: C-API and SQL function. This method turns on both options.
+				SQL function [code]load_extension()[/code] can only be used after enabling extension loading with this method. Preferably should be disabled after loading the extension to prevent SQL injections. Returns the SQLite return code.
+				
+				[codeblock]
+				var module_path = ProjectSettings.globalize_path("res://addons/godot-sqlite/extensions/spellfix.dll")
+				db.enable_load_extension(true)
+				db.query_with_bindings(
+				    "select load_extension(?, ?);", [
+				        module_path,
+				        "sqlite3_spellfix_init"
+				    ])
+				db.enable_load_extension(false)
+                [/codeblock]
+			</description>
+		</method>
+		<method name="load_extension">
+			<return type="int" />
+			<description>
+				Loads the extension in the given path. Does not require [method SQLite.enable_load_extension], as it only enables C-API during the call and disables it right after, utilizing the recommended extension loading method declared by the SQLite documentation ([url=https://www.sqlite.org/c3ref/load_extension.html]see[/url]). Returns the SQLite return code.
+				- [b]extension_path:[/b] the path to the compiled binary of the extension
+				- [b]entrypoint:[/b] the extension's entrypoint method (init function). It is defined in the .c file of the extension. 
+				Example for loading the spellfix module:
+				[codeblock]
+				db.load_extension("res://addons/godot-sqlite/extensions/spellfix.dll", "sqlite3_spellfix_init")
+				[/codeblock]
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="path" type="String" default="default">

--- a/src/gdsqlite.h
+++ b/src/gdsqlite.h
@@ -92,6 +92,9 @@ public:
 	int get_autocommit() const;
 	int compileoption_used(const String &option_name) const;
 
+	int load_extension(const String &p_path, const String &p_init_func_name);
+	int enable_load_extension(const bool &p_onoff);
+
 	// Properties.
 	void set_last_insert_rowid(const int64_t &p_last_insert_rowid);
 	int64_t get_last_insert_rowid() const;


### PR DESCRIPTION
SQLite presents an SQL function "load_extension()" for extension loading, but it is disabled by default for security.

These commits include two methods to achieve extension loading:

- **enable_load_extension:** sets a flag that enables both C-API and SQL function (NOT recommended by SQLite documentation, see [Security Warning](https://www.sqlite.org/c3ref/load_extension.html) section). But this is the only way for SQL function to work AFAIK.

- **load_extension:** provides an interface for C-API. It enables C-API only and disables it afterwards. 

Both methods basically call the corresponding sqlite3 functions with the given parameters, nothing fancy. Necessary explanations are also added into the documentation about how to use them.
