### PR TITLE
add `get_table_info` function

### DIFF
--- a/doc_classes/SQLite.xml
+++ b/doc_classes/SQLite.xml
@@ -119,6 +119,15 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_table_info">
+			<return type="bool" />
+			<description>
+				Gets the the info (specified using [method create_table]) of the table with name [code]table_name[/code]. This method is equivalent to the following query:
+				[codeblock]
+				db.query("PRAGMA table_info("+ table_name + ");")
+				[/codeblock]
+			</description>
+		</method>
 		<method name="insert_row">
 			<return type="bool" />
 			<description>

--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -11,6 +11,7 @@ void SQLite::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_table", "table_name", "table_data"), &SQLite::create_table);
 	ClassDB::bind_method(D_METHOD("drop_table", "table_name"), &SQLite::drop_table);
+	ClassDB::bind_method(D_METHOD("get_table_info", "table_name"), &SQLite::get_table_info);
 
 	ClassDB::bind_method(D_METHOD("backup_to", "destination"), &SQLite::backup_to);
 	ClassDB::bind_method(D_METHOD("restore_from", "source"), &SQLite::restore_from);
@@ -483,6 +484,14 @@ bool SQLite::drop_table(const String &p_name) {
 	String query_string;
 	/* Create SQL statement */
 	query_string = "DROP TABLE " + p_name + ";";
+
+	return query(query_string);
+}
+
+bool SQLite::get_table_info(const String &p_name) {
+	String query_string;
+	/* Create SQL statement */
+	query_string = "PRAGMA table_info(" + p_name + ");";
 
 	return query(query_string);
 }

--- a/src/gdsqlite.h
+++ b/src/gdsqlite.h
@@ -73,6 +73,7 @@ public:
 
 	bool create_table(const String &p_name, const Dictionary &p_table_dict);
 	bool drop_table(const String &p_name);
+	bool get_table_info(const String &p_name);
 
 	bool backup_to(String destination_path);
 	bool restore_from(String source_path);


### PR DESCRIPTION
This adds a new function to get the column names and data types of a table. The function is simply a predefined query like `drop_table()`.  I need this query to load databases whose structure I don't know and I think this should be a separate function as the `PRAGMA` statement is specific to sqlite and therefore not so well known.

Please let me know your thoughts on this.