### PR TITLE
Fix inconsistent file names on macOS.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ In chronological order based on the first contribution.
 - [Markus Sauermann (Sauermann)](https://github.com/Sauermann)
 - [Bernardo Rodriguez (Soleyu)](https://github.com/Soleyu)
 - [ugursoy](https://github.com/ugursoy)
+- [youngminz](https://github.com/youngminz)

--- a/SConstruct
+++ b/SConstruct
@@ -42,8 +42,8 @@ if env["platform"] == "macos":
             target,
             env["platform"],
             env["target"],
-            env["platform"],
             target_name,
+            env["platform"],
             env["target"]
         ),
         source=sources,


### PR DESCRIPTION
Compile commands:
```
scons platform=macos target=template_debug target_path=demo/addons/godot-sqlite/bin/ target_name=libgdsqlite -j16 arch=universal
scons platform=macos target=template_release target_path=demo/addons/godot-sqlite/bin/ target_name=libgdsqlite -j16 arch=universal
```
Before:
```
demo/addons/godot-sqlite/bin
├── binaries_here.txt
├── libgdsqlite.macos.template_debug.framework
│   ├── Resources
│   │   └── Info.plist
│   └── libmacos.libgdsqlite.template_debug
└── libgdsqlite.macos.template_release.framework
    ├── Resources
    │   └── Info.plist
    └── libmacos.libgdsqlite.template_release

5 directories, 5 files
```
After:
```
demo/addons/godot-sqlite/bin
├── binaries_here.txt
├── libgdsqlite.macos.template_debug.framework
│   ├── Resources
│   │   └── Info.plist
│   └── libgdsqlite.macos.template_debug
└── libgdsqlite.macos.template_release.framework
    ├── Resources
    │   └── Info.plist
    └── libgdsqlite.macos.template_release

5 directories, 5 files
```
Additionally, I confirmed that binaries for both Godot SQLite versions 4.3 and 4.4 are included in https://github.com/2shady4u/godot-sqlite/tree/assetlib-gdextension/addons/godot-sqlite/bin/libgdsqlite.macos.template_debug.framework and https://github.com/2shady4u/godot-sqlite/tree/assetlib-gdextension/addons/godot-sqlite/bin/libgdsqlite.macos.template_release.framework. However, I did not modify that branch as I'm not aware of potential side effects that might result from such modifications.