### PR TITLE
Load and export database as JSON-formatted string to enable database encryption

### DIFF
--- a/doc_classes/SQLite.xml
+++ b/doc_classes/SQLite.xml
@@ -162,6 +162,20 @@
 				Exports the database structure and content to [code]export_path.json[/code] as a backup or for ease of editing.
 			</description>
 		</method>
+		<method name="import_from_json_string">
+			<return type="bool" />
+			<description>
+				Drops all database tables and imports the database structure and content encoded in JSON-formatted input string.
+				Can be used together with [method SQLite.export_to_json_string] to implement database encryption.
+			</description>
+		</method>
+		<method name="export_to_json_string">
+			<return type="String" />
+			<description>
+				Returns the database structure and content as JSON-formatted string.
+				Can be used together with [method SQLite.import_from_json_string] to implement database encryption.
+			</description>
+		</method>
 		<method name="create_function">
 			<return type="bool" />
 			<description>

--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -26,6 +26,8 @@ void SQLite::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("import_from_json", "import_path"), &SQLite::import_from_json);
 	ClassDB::bind_method(D_METHOD("export_to_json", "export_path"), &SQLite::export_to_json);
+	ClassDB::bind_method(D_METHOD("import_from_json_string", "json_string"), &SQLite::import_from_json_string);
+	ClassDB::bind_method(D_METHOD("export_to_json_string"), &SQLite::export_to_json_string);
 
 	ClassDB::bind_method(D_METHOD("get_autocommit"), &SQLite::get_autocommit);
 	ClassDB::bind_method(D_METHOD("compileoption_used", "option_name"), &SQLite::compileoption_used);
@@ -819,13 +821,46 @@ bool SQLite::import_from_json(String import_path) {
 		ERR_PRINT("GDSQLite Error: " + String(std::strerror(errno)) + " (" + import_path + ")");
 		return false;
 	}
+
 	std::stringstream buffer;
 	buffer << ifs.rdbuf();
 	std::string str = buffer.str();
 	String json_string = String::utf8(str.c_str());
 	ifs.close();
 
-	/* Attempt to parse the result and, if unsuccessful, throw a parse error specifying the erroneous line */
+	return import_from_json_string(json_string);
+}
+
+bool SQLite::export_to_json(String export_path) {
+	String json_string = export_to_json_string();
+
+	/* Add .json to the import_path String if not present */
+	String ending = String(".json");
+	if (!export_path.ends_with(ending)) {
+		export_path += ending;
+	}
+	/* Find the real path */
+	export_path = ProjectSettings::get_singleton()->globalize_path(export_path.strip_edges());
+	CharString dummy_path = export_path.utf8();
+	const char *char_path = dummy_path.get_data();
+	//const char *char_path = export_path.alloc_c_string();
+
+	std::ofstream ofs(char_path, std::ios::trunc);
+	if (ofs.fail()) {
+		ERR_PRINT("GDSQLite Error: " + String(std::strerror(errno)) + " (" + export_path + ")");
+		return false;
+	}
+
+	CharString dummy_string = json_string.utf8();
+	ofs << dummy_string.get_data();
+	//ofs << json_string.alloc_c_string();
+	ofs.close();
+
+	return true;
+}
+
+bool SQLite::import_from_json_string(String json_string) {	
+	/* Attempt to parse the input json_string and, if unsuccessful, throw a parse error specifying the erroneous line */
 	Ref<JSON> json;
 	json.instantiate();
 	Error error = json->parse(json_string);
@@ -934,7 +969,7 @@ bool SQLite::import_from_json(String import_path) {
 	return true;
 }
 
-bool SQLite::export_to_json(String export_path) {
+String SQLite::export_to_json_string() {
 	/* Get all names and sql templates for all tables present in the database */
 	query(String("SELECT name,sql,type FROM sqlite_master;"));
 	TypedArray<Dictionary> database_array = query_result.duplicate(true);
@@ -943,7 +978,7 @@ bool SQLite::export_to_json(String export_path) {
 	remove_shadow_tables(database_array);
 #endif
 	int64_t number_of_objects = database_array.size();
-	/* Construct a Dictionary for each table, convert it to JSON and write it to file */
+	/* Construct a Dictionary for each table, convert it to JSON and write it to String */
 	for (int64_t i = 0; i <= number_of_objects - 1; i++) {
 		Dictionary object_dict = database_array[i];
 
@@ -989,31 +1024,10 @@ bool SQLite::export_to_json(String export_path) {
 		}
 	}
 
-	/* Add .json to the import_path String if not present */
-	String ending = String(".json");
-	if (!export_path.ends_with(ending)) {
-		export_path += ending;
-	}
-	/* Find the real path */
-	export_path = ProjectSettings::get_singleton()->globalize_path(export_path.strip_edges());
-	CharString dummy_path = export_path.utf8();
-	const char *char_path = dummy_path.get_data();
-	//const char *char_path = export_path.alloc_c_string();
-
-	std::ofstream ofs(char_path, std::ios::trunc);
-	if (ofs.fail()) {
-		ERR_PRINT("GDSQLite Error: " + String(std::strerror(errno)) + " (" + export_path + ")");
-		return false;
-	}
 	Ref<JSON> json;
 	json.instantiate();
 	String json_string = json->stringify(database_array, "\t");
-	CharString dummy_string = json_string.utf8();
-	ofs << dummy_string.get_data();
-	//ofs << json_string.alloc_c_string();
-	ofs.close();
-
-	return true;
+	return json_string;
 }
 
 bool SQLite::validate_json(const Array &database_array, std::vector<object_struct> &objects_to_import) {

--- a/src/gdsqlite.h
+++ b/src/gdsqlite.h
@@ -91,6 +91,9 @@ public:
 	bool import_from_json(String import_path);
 	bool export_to_json(String export_path);
 
+	bool import_from_json_string(String json_string);
+	String export_to_json_string();
+
 	int get_autocommit() const;
 	int compileoption_used(const String &option_name) const;
 


### PR DESCRIPTION
- Added import_from_json_string and export_to_json_string functions, which are now also internally used by import_from_json and export_to_json
- Added documentation for import_from_json_string and export_to_json_string
- Added example of AES database encryption to demo