### PR TITLE
Fix macOS bundle executable name

### DIFF
--- a/demo/addons/godot-sqlite/bin/libgdsqlite.macos.template_debug.framework/Resources/Info.plist
+++ b/demo/addons/godot-sqlite/bin/libgdsqlite.macos.template_debug.framework/Resources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>libgdsqlite.template_debug</string>
+	<string>libgdsqlite.macos.template_debug</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.godotengine.libgdsqlite</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/demo/addons/godot-sqlite/bin/libgdsqlite.macos.template_release.framework/Resources/Info.plist
+++ b/demo/addons/godot-sqlite/bin/libgdsqlite.macos.template_release.framework/Resources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>libgdsqlite.template_release</string>
+	<string>libgdsqlite.macos.template_release</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.godotengine.libgdsqlite</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
Hey there!

These names in the bundle plist must match the actual executable name (last changed in #205, I believe), otherwise codesign fails. At least with [`rcodesign`](https://gregoryszorc.com/docs/apple-codesign/stable/) I get "could not find main executable of presumed nested bundle", which leads to an improperly signed bundle which fails notarization.

It is possible that genuine Apple toolchain somehow works around this and finds the executable regardless, I didn't check. Though from my own experience building and signing GDExtension on macOS the contents of plist files is very sensitive, so best it is as correct as possible.