### PR TITLE
Add enable_rpath option to SConstruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Following SQLite extensions are supported by this plugin, although they require 
 |------------------------------------------------------------------------------|-----------------------|---------|
 | [SQLite FTS5 Extension](https://sqlite.org/fts5.html)                        | enable_fts5           | no      |
 | [Built-In Mathematical SQL Functions](https://sqlite.org/lang_mathfunc.html) | enable_math_functions | no      |
+| [SQLite R\*Tree Module](https://sqlite.org/rtree.html)                       | enable_rtree          | no      |
 
 To re-compile the plugin with XYZ enabled, follow the instructions as defined in the 'How to contribute?'-section below.  
 Depending on your choice, following modifications have to be made:

--- a/SConstruct
+++ b/SConstruct
@@ -14,6 +14,12 @@ options: list = [
         help="Enable SQLite's Built-in Mathematical SQL Functions",
         define="SQLITE_ENABLE_MATH_FUNCTIONS",
     ),
+    CompileTimeOption(
+        key="enable_rtree",
+        name="RTREE",
+        help="Enable SQLite's R*Tree Module",
+        define="SQLITE_ENABLE_RTREE",
+    ),
 ]
 
 target_path = ARGUMENTS.pop("target_path", "demo/addons/godot-sqlite/bin/")


### PR DESCRIPTION
I'm using the R*Tree module in my project.  I just added the option to SConstruct and updated README.md accordingly.