### PR TITLE
add *.so and *.dll to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ mono_crash.*.json
 *.pdb
 *.lib
 *.bc
+*.so
+*.dll
 
 # OS generated files #
 ######################


### PR DESCRIPTION
These files become a nuisance when using godot-sqlite as a git submodule and building for Windows and Android.  I don't want to have to move, delete or rebuild the files when I'm ready to check in sources in the parent git repository.