### PR TITLE
Introduced prepared statement APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ Additionally, a video tutorial by [Mitch McCollum (finepointcgi)](https://github
 
     Query the database using the raw SQL statement defined in `query_string`.
 
+- SQLiteStatement = **prepare(** String query_string **)**
+
+    Prepare and compile `query_string` into an optimized reusable form.
+
+    **Example usage**:
+
+    ```gdscript
+    var statement = db.prepare("SELECT id, name FROM company WHERE age >= :min_age ORDER BY id;")
+    statement.bind_named({"min_age": 30})
+    var rows = statement.fetch_all()
+    statement.finalize() # Free the statement
+    ```
+
+    `SQLiteStatement` supports `bind()`, `bind_all()`, `bind_named()`, `step()`, `get_row()`, `fetch_all()`, `reset()`, and `finalize()`.
+
 - Boolean success = **query_with_bindings(** String query_string, Array param_bindings **)**
 
     Binds the parameters using nameless variables contained in the `param_bindings`-variable to the query. Using this function stops any possible attempts at SQL data injection as the parameters are sanitized. More information regarding parameter bindings can be found [here](https://www.sqlite.org/c3ref/bind_blob.html).

--- a/demo/database.gd
+++ b/demo/database.gd
@@ -34,6 +34,7 @@ func _ready():
 
 	# Enable/disable examples here:
 	example_of_basic_database_querying()
+	example_of_prepared_statements()
 	example_of_in_memory_and_foreign_key_support()
 	example_of_call_external_functions()
 	example_of_blob_io()
@@ -204,6 +205,80 @@ func example_of_basic_database_querying():
 
 	# Close the imported database
 	db.close_db()
+
+# Basic prepared statement example showing positional and named bindings.
+func example_of_prepared_statements():
+	db = SQLite.new()
+	db.path = ":memory:"
+	db.verbosity_level = verbosity_level
+	db.open_db()
+
+	db.query("CREATE TABLE prepared_demo(id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER NOT NULL);")
+
+	var insert_statement = db.prepare("INSERT INTO prepared_demo(id, name, age) VALUES(?, ?, ?);")
+	if insert_statement == null:
+		cprint("Failed to create insert prepared statement: " + db.error_message)
+		db.close_db()
+		return
+	cprint("Insert statement status (property/method): " + str(insert_statement.status) + "/" + str(insert_statement.get_status()))
+
+	var prepared_names := ["Ivy", "Noah", "Mika", "Rhea"]
+	var prepared_ages := [28, 41, 19, 35]
+	for i in range(0, prepared_names.size()):
+		insert_statement.clear_bindings()
+		if not insert_statement.bind_all([i + 1, prepared_names[i], prepared_ages[i]]):
+			cprint("Insert bind failed: " + insert_statement.get_error_message())
+			break
+		if not insert_statement.execute():
+			cprint("Insert execution failed: " + insert_statement.get_error_message())
+			break
+		insert_statement.reset()
+
+	insert_statement.finalize()
+	cprint("Insert statement status after finalize: " + str(insert_statement.status))
+
+	var select_statement = db.prepare("SELECT id, name, age FROM prepared_demo WHERE age >= :min_age ORDER BY id;")
+	if select_statement == null:
+		cprint("Failed to create select prepared statement: " + db.error_message)
+		db.close_db()
+		return
+	cprint("Select statement status (property/method): " + str(select_statement.status) + "/" + str(select_statement.get_status()))
+
+	if select_statement.bind_named({"min_age": 30}):
+		var all_rows: Array = select_statement.fetch_all()
+		cprint("Prepared fetch_all (age >= 30): " + str(all_rows))
+	else:
+		cprint("Select named bind failed: " + select_statement.get_error_message())
+
+	select_statement.reset()
+	select_statement.clear_bindings()
+
+	if not select_statement.bind_named({"min_age": 20}):
+		cprint("Select re-bind failed: " + select_statement.get_error_message())
+	else:
+		var stepped_rows: Array = []
+		var step_result : int = select_statement.step()
+		while step_result == SQLite.SQLITE_ROW:
+			stepped_rows.append(select_statement.get_row())
+			step_result = select_statement.step()
+		if step_result != SQLite.SQLITE_DONE:
+			cprint("Prepared step failed (" + str(step_result) + "): " + select_statement.get_error_message())
+		cprint("Prepared step rows (age >= 20): " + str(stepped_rows))
+
+	select_statement.finalize()
+	cprint("Select statement status after finalize: " + str(select_statement.get_status()))
+
+	var connection_statement = db.prepare("SELECT 42;")
+	if connection_statement == null:
+		cprint("Failed to create connection status statement: " + db.error_message)
+		db.close_db()
+		return
+
+	cprint("Connection statement status before db.close_db(): " + str(connection_statement.status))
+	db.close_db()
+	cprint("Connection statement status after db.close_db(): " + str(connection_statement.get_status()))
+	connection_statement.bind(0, 0)
+	cprint("Connection statement error via getter: " + connection_statement.get_error_message())
 
 # This example demonstrates the in-memory and foreign key support. It's
 # rather contrived, but it gets the point across.

--- a/doc_classes/SQLite.xml
+++ b/doc_classes/SQLite.xml
@@ -65,6 +65,12 @@
 				Query the database using the raw SQL statement defined in [code]query_string[/code].
 			</description>
 		</method>
+		<method name="prepare">
+			<return type="SQLiteStatement" />
+			<description>
+				Prepare and compile a SQL statement for repeated execution. The returned [code]SQLiteStatement[/code] can be bound, stepped and reset multiple times without recompiling SQL.
+			</description>
+		</method>
 		<method name="query_with_bindings">
 			<return type="bool" />
 			<description>

--- a/doc_classes/SQLiteStatement.xml
+++ b/doc_classes/SQLiteStatement.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<class name="SQLiteStatement" inherits="RefCounted"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Prepared statement handle returned by [code]SQLite.prepare()[/code].
+	</brief_description>
+	<description>
+		A handle to a reusable preparsed and precompiled SQL statement, designed efficient repeated execution.
+		Typical workflow: prepare once, bind parameters, execute or step rows, reset, repeat, then [method finalize].
+	</description>
+	<methods>
+		<method name="bind">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Bind a positional parameter using zero-based parameter index.
+			</description>
+		</method>
+		<method name="bind_all">
+			<return type="bool" />
+			<param index="0" name="values" type="Array" />
+			<description>
+				Bind all positional parameters in order. Extra values are ignored.
+			</description>
+		</method>
+		<method name="bind_named">
+			<return type="bool" />
+			<param index="0" name="values" type="Dictionary" />
+			<description>
+				Bind named parameters from a dictionary. Keys are passed without SQL prefixes ([code]:[/code], [code]@[/code], [code]$[/code], [code]?[/code]).
+			</description>
+		</method>
+		<method name="clear_bindings">
+			<return type="void" />
+			<description>
+				Clear all currently bound parameters.
+			</description>
+		</method>
+		<method name="reset">
+			<return type="bool" />
+			<description>
+				Reset statement execution state so the statement can be executed again.
+			</description>
+		</method>
+		<method name="execute">
+			<return type="bool" />
+			<description>
+				Execute the statement until completion ([code]SQLITE_DONE[/code]). For row-producing queries this steps through all rows.
+			</description>
+		</method>
+		<method name="step">
+			<return type="int" />
+			<description>
+				Perform a single SQLite step and return SQLite status code (for example [code]SQLITE_ROW[/code], [code]SQLITE_DONE[/code], or an error code).
+			</description>
+		</method>
+		<method name="fetch_all">
+			<return type="Array" />
+			<description>
+				Step the statement until completion and return all resulting rows as an array of dictionaries.
+			</description>
+		</method>
+		<method name="get_row">
+			<return type="Dictionary" />
+			<description>
+				Return the row produced by the most recent [method step] call that returned [code]SQLITE_ROW[/code].
+			</description>
+		</method>
+		<method name="get_column_names">
+			<return type="PackedStringArray" />
+			<description>
+				Return the statement's column names in column order.
+			</description>
+		</method>
+		<method name="get_parameter_count">
+			<return type="int" />
+			<description>
+				Return the number of bind parameters defined by this statement.
+			</description>
+		</method>
+		<method name="finalize">
+			<return type="void" />
+			<description>
+				Release the underlying SQLite statement resources. After finalization, the statement is no longer usable.
+			</description>
+		</method>
+		<method name="get_status">
+			<return type="int" />
+			<description>
+				Return the current statement lifecycle status as one of [constant UNINITIALIZED], [constant INITIALIZED], [constant FINALIZED], or [constant CONNECTION_FINALIZED].
+			</description>
+		</method>
+		<method name="get_error_message">
+			<return type="String" />
+			<description>
+				Return the latest SQLite statement/query error message.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="status" type="int" default="1">
+			Current statement lifecycle status. Alias for [method get_status]. Possible values are [constant UNINITIALIZED], [constant INITIALIZED], [constant FINALIZED], and [constant CONNECTION_FINALIZED].
+		</member>
+		<member name="error_message" type="String" default="&quot;&quot;">
+			Contains the latest SQLite statement/query error message. Alias for [method get_error_message].
+		</member>
+	</members>
+	<signals>
+	</signals>
+	<constants>
+		<constant name="UNINITIALIZED" value="0">
+			Statement has not been initialized with a valid SQLite statement handle.
+		</constant>
+		<constant name="INITIALIZED" value="1">
+			Statement is initialized and can be used.
+		</constant>
+		<constant name="FINALIZED" value="2">
+			Statement has been finalized by script code.
+		</constant>
+		<constant name="CONNECTION_FINALIZED" value="3">
+			Statement was invalidated because the associated SQLite connection was closed.
+		</constant>
+	</constants>
+</class>

--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -1,4 +1,5 @@
 #include "gdsqlite.hpp"
+#include <godot_cpp/core/object.hpp>
 
 using namespace godot;
 
@@ -7,6 +8,7 @@ void SQLite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open_db"), &SQLite::open_db);
 	ClassDB::bind_method(D_METHOD("close_db"), &SQLite::close_db);
 	ClassDB::bind_method(D_METHOD("query", "query_string"), &SQLite::query);
+	ClassDB::bind_method(D_METHOD("prepare", "query_string"), &SQLite::prepare);
 	ClassDB::bind_method(D_METHOD("query_with_bindings", "query_string", "param_bindings"), &SQLite::query_with_bindings);
 	ClassDB::bind_method(D_METHOD("query_with_named_bindings", "query_string", "param_bindings"), &SQLite::query_with_named_bindings);
 
@@ -187,6 +189,7 @@ bool SQLite::open_db() {
 
 bool SQLite::close_db() {
 	if (db) {
+		finalize_statements();
 		// Cannot close database!
 		if (sqlite3_close_v2(db) != SQLITE_OK) {
 			ERR_PRINT("GDSQLite Error: Can't close database!");
@@ -220,26 +223,105 @@ bool SQLite::query(const String &p_query) {
 	return query_with_bindings(p_query, Array());
 }
 
-bool SQLite::prepare_statement(const CharString &p_query, sqlite3_stmt **out_stmt, const char** pzTail) {
-    if (verbosity_level > VerbosityLevel::NORMAL) {
-        UtilityFunctions::print(p_query.get_data());
-    }
+Ref<SQLiteStatement> SQLite::prepare(const String &p_query) {
+	Ref<SQLiteStatement> statement;
+	if (!db) {
+		ERR_PRINT("GDSQLite Error: Can't prepare statement if connection is not open!");
+		return statement;
+	}
 
-    const char *sql = p_query.get_data();
+	sqlite3_stmt *prepared_stmt = nullptr;
+	const char *pzTail = nullptr;
+	CharString char_query = p_query.utf8();
 
-    query_result.clear();
+	int rc = sqlite3_prepare_v2(db, char_query.get_data(), -1, &prepared_stmt, &pzTail);
+	const char *zErrMsg = sqlite3_errmsg(db);
+	error_message = String::utf8(zErrMsg);
+	if (rc != SQLITE_OK) {
+		ERR_PRINT("GDSQLite Error: Failed to prepare statement: " + error_message);
+		sqlite3_finalize(prepared_stmt);
+		return statement;
+	}
 
-    int rc = sqlite3_prepare_v2(db, sql, -1, out_stmt, pzTail);
-    const char *zErrMsg = sqlite3_errmsg(db);
-    error_message = String::utf8(zErrMsg);
+	String sTail = String::utf8(pzTail).strip_edges();
+	if (!sTail.is_empty()) {
+		WARN_PRINT("GDSQLite Warning: The prepared statement contains additional SQL after the first statement. Only the first statement is prepared.");
+	}
 
-    if (rc != SQLITE_OK) {
-        ERR_PRINT(" --> SQL error: " + error_message);
-        sqlite3_finalize(*out_stmt);
-        return false;
-    }
+	statement.instantiate();
+	statement->initialize(db, prepared_stmt);
+	track_statement_instance(statement->get_instance_id());
+	return statement;
+}
 
-    return true;
+void SQLite::track_statement_instance(uint64_t p_instance_id) {
+	prune_statement_instances();
+	statement_instance_ids.push_back(p_instance_id);
+}
+
+void SQLite::prune_statement_instances() {
+	std::vector<uint64_t> active_instances;
+	active_instances.reserve(statement_instance_ids.size());
+
+	for (auto instance_id : statement_instance_ids) {
+		Object *obj = ObjectDB::get_instance(instance_id);
+
+		if (obj == nullptr) {
+			continue;
+		}
+
+		SQLiteStatement *statement = Object::cast_to<SQLiteStatement>(obj);
+
+		if (statement == nullptr) {
+			continue;
+		}
+
+		if (statement->is_valid()) {
+			active_instances.push_back(instance_id);
+		}
+	}
+
+	statement_instance_ids = active_instances;
+}
+
+void SQLite::finalize_statements() {
+	for (auto instance_id : statement_instance_ids) {
+		Object *obj = ObjectDB::get_instance(instance_id);
+		if (obj == nullptr) {
+			continue;
+		}
+
+		SQLiteStatement *statement = Object::cast_to<SQLiteStatement>(obj);
+		if (statement == nullptr) {
+			continue;
+		}
+
+		statement->connection_finalized();
+	}
+
+	statement_instance_ids.clear();
+}
+
+bool SQLite::prepare_statement(const CharString &p_query, sqlite3_stmt **out_stmt, const char **pzTail) {
+	if (verbosity_level > VerbosityLevel::NORMAL) {
+		UtilityFunctions::print(p_query.get_data());
+	}
+
+	const char *sql = p_query.get_data();
+
+	query_result.clear();
+
+	int rc = sqlite3_prepare_v2(db, sql, -1, out_stmt, pzTail);
+	const char *zErrMsg = sqlite3_errmsg(db);
+	error_message = String::utf8(zErrMsg);
+
+	if (rc != SQLITE_OK) {
+		ERR_PRINT(" --> SQL error: " + error_message);
+		sqlite3_finalize(*out_stmt);
+		return false;
+	}
+
+	return true;
 }
 
 bool SQLite::bind_parameter(Variant binding_value, sqlite3_stmt *stmt, int i) {
@@ -256,13 +338,12 @@ bool SQLite::bind_parameter(Variant binding_value, sqlite3_stmt *stmt, int i) {
 			sqlite3_bind_double(stmt, i + 1, binding_value);
 			break;
 		case Variant::STRING:
-		case Variant::STRING_NAME:
-			{
-				const CharString dummy_binding = (binding_value.operator String()).utf8();
-				const char *binding = dummy_binding.get_data();
-				sqlite3_bind_text(stmt, i + 1, binding, -1, SQLITE_TRANSIENT);
-			}
+		case Variant::STRING_NAME: {
+			const CharString dummy_binding = (binding_value.operator String()).utf8();
+			const char *binding = dummy_binding.get_data();
+			sqlite3_bind_text(stmt, i + 1, binding, -1, SQLITE_TRANSIENT);
 			break;
+		}
 
 		case Variant::PACKED_BYTE_ARRAY: {
 			PackedByteArray binding = ((const PackedByteArray &)binding_value);
@@ -417,9 +498,8 @@ bool SQLite::query_with_named_bindings(const String &p_query, Dictionary param_b
 		const char *param_name = sqlite3_bind_parameter_name(stmt, i + 1);
 		if (nullptr == param_name) {
 			ERR_PRINT(vformat(
-				"GDSQLite Error: Parameter index %d is most likely nameless and can't assign named parameter!",
-				i + 1
-			));			
+					"GDSQLite Error: Parameter index %d is most likely nameless and can't assign named parameter!",
+					i + 1));
 			sqlite3_finalize(stmt);
 			return false;
 		}
@@ -431,9 +511,8 @@ bool SQLite::query_with_named_bindings(const String &p_query, Dictionary param_b
 			binding_value = param_bindings[non_prefixed_name];
 		} else {
 			ERR_PRINT(vformat(
-				"GDSQLite Error: Insufficient parameter names to satisfy bindings in statement! Missing parameter: %s",
-				String::utf8(non_prefixed_name)
-			));
+					"GDSQLite Error: Insufficient parameter names to satisfy bindings in statement! Missing parameter: %s",
+					String::utf8(non_prefixed_name)));
 			sqlite3_finalize(stmt);
 			return false;
 		}
@@ -840,13 +919,12 @@ static void function_callback(sqlite3_context *context, int argc, sqlite3_value 
 			break;
 
 		case Variant::STRING:
-		case Variant::STRING_NAME:
-			{
-				const CharString dummy_binding = (output.operator String()).utf8();
-				const char *binding = dummy_binding.get_data();
-				sqlite3_result_text(context, binding, -1, SQLITE_STATIC);
-			}
+		case Variant::STRING_NAME: {
+			const CharString dummy_binding = (output.operator String()).utf8();
+			const char *binding = dummy_binding.get_data();
+			sqlite3_result_text(context, binding, -1, SQLITE_STATIC);
 			break;
+		}
 
 		case Variant::PACKED_BYTE_ARRAY: {
 			PackedByteArray arr = ((const PackedByteArray &)output);

--- a/src/gdsqlite_statement.cpp
+++ b/src/gdsqlite_statement.cpp
@@ -1,0 +1,434 @@
+#include "gdsqlite_statement.hpp"
+#include <cstring>
+
+using namespace godot;
+
+void SQLiteStatement::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("bind", "index", "value"), &SQLiteStatement::bind);
+	ClassDB::bind_method(D_METHOD("bind_all", "values"), &SQLiteStatement::bind_all);
+	ClassDB::bind_method(D_METHOD("bind_named", "values"), &SQLiteStatement::bind_named);
+	ClassDB::bind_method(D_METHOD("clear_bindings"), &SQLiteStatement::clear_bindings);
+
+	ClassDB::bind_method(D_METHOD("reset"), &SQLiteStatement::reset);
+	ClassDB::bind_method(D_METHOD("execute"), &SQLiteStatement::execute);
+	ClassDB::bind_method(D_METHOD("step"), &SQLiteStatement::step);
+	ClassDB::bind_method(D_METHOD("fetch_all"), &SQLiteStatement::fetch_all);
+	ClassDB::bind_method(D_METHOD("get_row"), &SQLiteStatement::get_row);
+	ClassDB::bind_method(D_METHOD("get_column_names"), &SQLiteStatement::get_column_names);
+	ClassDB::bind_method(D_METHOD("get_parameter_count"), &SQLiteStatement::get_parameter_count);
+
+	ClassDB::bind_method(D_METHOD("finalize"), &SQLiteStatement::finalize);
+	ClassDB::bind_method(D_METHOD("is_valid"), &SQLiteStatement::is_valid);
+	ClassDB::bind_method(D_METHOD("get_status"), &SQLiteStatement::get_status);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "status"), "", "get_status");
+
+	ClassDB::bind_method(D_METHOD("get_error_message"), &SQLiteStatement::get_error_message);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "error_message"), "", "get_error_message");
+
+	BIND_ENUM_CONSTANT(UNINITIALIZED);
+	BIND_ENUM_CONSTANT(INITIALIZED);
+	BIND_ENUM_CONSTANT(FINALIZED);
+	BIND_ENUM_CONSTANT(CONNECTION_FINALIZED);
+}
+
+SQLiteStatement::~SQLiteStatement() {
+	finalize();
+}
+
+void SQLiteStatement::initialize(sqlite3 *p_db, sqlite3_stmt *p_stmt) {
+	db = p_db;
+	stmt = p_stmt;
+	status = (stmt != nullptr && db != nullptr) ? INITIALIZED : UNINITIALIZED;
+	reset_row_state();
+	column_names.clear();
+}
+
+void SQLiteStatement::connection_finalized() {
+	release_statement(CONNECTION_FINALIZED);
+	db = nullptr;
+}
+
+bool SQLiteStatement::check_valid(const char *p_method_name) {
+	if (status == FINALIZED) {
+		error_message = "Statement was explicitly finalized and can no longer be used.";
+		ERR_PRINT("GDSQLite Error: Cannot call " + String(p_method_name) + " because the statement was explicitly finalized.");
+		return false;
+	}
+
+	if (status == CONNECTION_FINALIZED || db == nullptr) {
+		error_message = "Statement is invalid because the associated database connection is no longer available.";
+		ERR_PRINT("GDSQLite Error: Cannot call " + String(p_method_name) + " because the associated database is no longer available.");
+		return false;
+	}
+
+	if (status == UNINITIALIZED) {
+		error_message = "Statement is uninitialized.";
+		ERR_PRINT("GDSQLite Error: Cannot call " + String(p_method_name) + " on an invalid statement.");
+		return false;
+	}
+
+	if (status != INITIALIZED || stmt == nullptr) {
+		error_message = "Statement is in an invalid internal state.";
+		ERR_PRINT("GDSQLite Error: Cannot call " + String(p_method_name) + " on a corrupted statement state.");
+		return false;
+	}
+
+	return true;
+}
+
+void SQLiteStatement::release_statement(StatementStatus p_next_status) {
+	switch (p_next_status) {
+		case FINALIZED:
+		case CONNECTION_FINALIZED:
+			status = p_next_status;
+			break;
+
+		default:
+			ERR_PRINT("GDSQLite Error: Unexpected release_statement status transition.");
+			break;
+	}
+
+	if (stmt == nullptr) {
+		reset_row_state();
+		column_names.clear();
+		return;
+	}
+
+	int rc = sqlite3_finalize(stmt);
+	stmt = nullptr;
+
+	if (status == INITIALIZED) {
+		status = UNINITIALIZED;
+	}
+
+	reset_row_state();
+	column_names.clear();
+
+	if (db != nullptr && rc != SQLITE_OK) {
+		error_message = String::utf8(sqlite3_errmsg(db));
+		ERR_PRINT("GDSQLite Error: " + error_message);
+	}
+}
+
+void SQLiteStatement::cache_column_names() {
+	if (stmt == nullptr || !column_names.is_empty()) {
+		return;
+	}
+
+	int column_count = sqlite3_column_count(stmt);
+
+	for (int i = 0; i < column_count; i++) {
+		const char *column_name = sqlite3_column_name(stmt, i);
+		column_names.append(String::utf8(column_name));
+	}
+}
+
+void SQLiteStatement::reset_row_state() {
+	has_row = false;
+	current_row.clear();
+}
+
+Dictionary SQLiteStatement::marshal_current_row() const {
+	Dictionary row;
+
+	if (stmt == nullptr) {
+		return row;
+	}
+
+	int column_count = sqlite3_column_count(stmt);
+
+	for (int i = 0; i < column_count; i++) {
+		StringName column_name;
+
+		if (i < column_names.size()) {
+			column_name = StringName(column_names[i]);
+		} else {
+			column_name = StringName(String::utf8(sqlite3_column_name(stmt, i)));
+		}
+
+		Variant column_value;
+
+		switch (sqlite3_column_type(stmt, i)) {
+			case SQLITE_INTEGER:
+				column_value = (int64_t)sqlite3_column_int64(stmt, i);
+				break;
+
+			case SQLITE_FLOAT:
+				column_value = sqlite3_column_double(stmt, i);
+				break;
+
+			case SQLITE_TEXT:
+				column_value = String::utf8((const char *)sqlite3_column_text(stmt, i));
+				break;
+
+			case SQLITE_BLOB: {
+				int bytes = sqlite3_column_bytes(stmt, i);
+				PackedByteArray arr;
+				arr.resize(bytes);
+				if (bytes > 0) {
+					memcpy(arr.ptrw(), sqlite3_column_blob(stmt, i), bytes);
+				}
+				column_value = arr;
+				break;
+			}
+
+			case SQLITE_NULL:
+				column_value = Variant();
+				break;
+
+			default:
+				column_value = Variant();
+				break;
+		}
+
+		row[column_name] = column_value;
+	}
+	return row;
+}
+
+bool SQLiteStatement::bind_sqlite_parameter(const Variant &p_binding_value, int p_sqlite_index) {
+	switch (p_binding_value.get_type()) {
+		case Variant::NIL:
+			sqlite3_bind_null(stmt, p_sqlite_index);
+			break;
+
+		case Variant::BOOL:
+		case Variant::INT:
+			sqlite3_bind_int64(stmt, p_sqlite_index, int64_t(p_binding_value));
+			break;
+
+		case Variant::FLOAT:
+			sqlite3_bind_double(stmt, p_sqlite_index, p_binding_value);
+			break;
+
+		case Variant::STRING:
+		case Variant::STRING_NAME: {
+			const CharString utf8_binding = (p_binding_value.operator String()).utf8();
+			sqlite3_bind_text(stmt, p_sqlite_index, utf8_binding.get_data(), -1, SQLITE_TRANSIENT);
+			break;
+		}
+
+		case Variant::PACKED_BYTE_ARRAY: {
+			PackedByteArray binding = ((const PackedByteArray &)p_binding_value);
+			if (binding.size() == 0) {
+				sqlite3_bind_null(stmt, p_sqlite_index);
+			} else {
+				sqlite3_bind_blob64(stmt, p_sqlite_index, binding.ptr(), binding.size(), SQLITE_TRANSIENT);
+			}
+			break;
+		}
+
+		default:
+			error_message = "Binding a parameter of this Variant type is not supported.";
+			ERR_PRINT("GDSQLite Error: " + error_message);
+			return false;
+	}
+
+	return true;
+}
+
+bool SQLiteStatement::bind(const int64_t &p_index, const Variant &p_binding_value) {
+	if (!check_valid("bind")) {
+		return false;
+	}
+
+	int parameter_count = sqlite3_bind_parameter_count(stmt);
+
+	if (p_index < 0 || p_index >= parameter_count) {
+		error_message = "Binding index is out of range.";
+		ERR_PRINT("GDSQLite Error: " + error_message);
+		return false;
+	}
+
+	return bind_sqlite_parameter(p_binding_value, (int)p_index + 1);
+}
+
+bool SQLiteStatement::bind_all(const Array &p_values) {
+	if (!check_valid("bind_all")) {
+		return false;
+	}
+
+	int parameter_count = sqlite3_bind_parameter_count(stmt);
+
+	if (p_values.size() < parameter_count) {
+		error_message = "Insufficient number of parameters to satisfy required bindings in statement.";
+		ERR_PRINT("GDSQLite Error: " + error_message);
+		return false;
+	}
+
+	for (int i = 0; i < parameter_count; i++) {
+		if (!bind_sqlite_parameter(p_values[i], i + 1)) {
+			return false;
+		}
+	}
+
+	if (p_values.size() > parameter_count) {
+		WARN_PRINT("GDSQLite Warning: Provided number of bindings exceeded the required number in statement.");
+	}
+
+	return true;
+}
+
+bool SQLiteStatement::bind_named(const Dictionary &p_values) {
+	if (!check_valid("bind_named")) {
+		return false;
+	}
+
+	int parameter_count = sqlite3_bind_parameter_count(stmt);
+
+	for (int i = 0; i < parameter_count; i++) {
+		const char *parameter_name = sqlite3_bind_parameter_name(stmt, i + 1);
+
+		if (parameter_name == nullptr) {
+			error_message = "Named binding failed because a parameter in the statement is nameless.";
+			ERR_PRINT("GDSQLite Error: " + error_message);
+			return false;
+		}
+
+		String parameter_key = String::utf8(parameter_name + 1);
+		Variant value;
+
+		if (p_values.has(parameter_key)) {
+			value = p_values[parameter_key];
+		} else if (p_values.has(StringName(parameter_key))) {
+			value = p_values[StringName(parameter_key)];
+		} else {
+			error_message = "Missing named parameter: " + parameter_key;
+			ERR_PRINT("GDSQLite Error: " + error_message);
+			return false;
+		}
+
+		if (!bind_sqlite_parameter(value, i + 1)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void SQLiteStatement::clear_bindings() {
+	if (!check_valid("clear_bindings")) {
+		return;
+	}
+
+	sqlite3_clear_bindings(stmt);
+}
+
+bool SQLiteStatement::reset() {
+	if (!check_valid("reset")) {
+		return false;
+	}
+
+	reset_row_state();
+	int rc = sqlite3_reset(stmt);
+
+	if (rc != SQLITE_OK) {
+		error_message = String::utf8(sqlite3_errmsg(db));
+		ERR_PRINT("GDSQLite Error: " + error_message);
+		return false;
+	}
+
+	return true;
+}
+
+bool SQLiteStatement::execute() {
+	if (!check_valid("execute")) {
+		return false;
+	}
+
+	while (true) {
+		int64_t rc = step();
+
+		if (rc == SQLITE_ROW) {
+			continue;
+		}
+
+		return rc == SQLITE_DONE;
+	}
+}
+
+int64_t SQLiteStatement::step() {
+	if (!check_valid("step")) {
+		return SQLITE_MISUSE;
+	}
+
+	cache_column_names();
+	int rc = sqlite3_step(stmt);
+
+	if (rc == SQLITE_ROW) {
+		has_row = true;
+		current_row = marshal_current_row();
+		return rc;
+	}
+
+	if (rc == SQLITE_DONE) {
+		reset_row_state();
+		return rc;
+	}
+
+	reset_row_state();
+	error_message = String::utf8(sqlite3_errmsg(db));
+	ERR_PRINT("GDSQLite Error: " + error_message);
+	return rc;
+}
+
+TypedArray<Dictionary> SQLiteStatement::fetch_all() {
+	TypedArray<Dictionary> rows;
+
+	if (!check_valid("fetch_all")) {
+		return rows;
+	}
+
+	while (true) {
+		int64_t rc = step();
+
+		if (rc == SQLITE_ROW) {
+			rows.append(current_row.duplicate(true));
+			continue;
+		}
+
+		break;
+	}
+
+	return rows;
+}
+
+Dictionary SQLiteStatement::get_row() const {
+	if (!has_row) {
+		return Dictionary();
+	}
+
+	return current_row.duplicate(true);
+}
+
+PackedStringArray SQLiteStatement::get_column_names() {
+	if (status == INITIALIZED && column_names.is_empty()) {
+		cache_column_names();
+	}
+
+	return column_names;
+}
+
+int64_t SQLiteStatement::get_parameter_count() const {
+	if (status != INITIALIZED) {
+		return 0;
+	}
+
+	return sqlite3_bind_parameter_count(stmt);
+}
+
+void SQLiteStatement::finalize() {
+	release_statement(FINALIZED);
+}
+
+bool SQLiteStatement::is_valid() const {
+	return status == INITIALIZED;
+}
+
+int64_t SQLiteStatement::get_status() const {
+	return status;
+}
+
+String SQLiteStatement::get_error_message() const {
+	return error_message;
+}

--- a/src/gdsqlite_statement.hpp
+++ b/src/gdsqlite_statement.hpp
@@ -1,0 +1,78 @@
+#ifndef GDSQLITE_STATEMENT_H
+#define GDSQLITE_STATEMENT_H
+
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/string_name.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include <sqlite/sqlite3.h>
+
+namespace godot {
+
+class SQLiteStatement : public RefCounted {
+	GDCLASS(SQLiteStatement, RefCounted)
+
+public:
+	enum StatementStatus : int {
+		UNINITIALIZED = 0,
+		INITIALIZED = 1,
+		FINALIZED = 2,
+		CONNECTION_FINALIZED = 3
+	};
+
+private:
+	sqlite3 *db = nullptr;
+	sqlite3_stmt *stmt = nullptr;
+	StatementStatus status = UNINITIALIZED;
+	bool has_row = false;
+	String error_message = "";
+	Dictionary current_row;
+	PackedStringArray column_names;
+
+	bool check_valid(const char *p_method_name);
+	void release_statement(StatementStatus p_next_status);
+	void cache_column_names();
+	void reset_row_state();
+	Dictionary marshal_current_row() const;
+	bool bind_sqlite_parameter(const Variant &p_binding_value, int p_sqlite_index);
+
+protected:
+	static void _bind_methods();
+
+public:
+	SQLiteStatement() = default;
+	~SQLiteStatement();
+
+	void initialize(sqlite3 *p_db, sqlite3_stmt *p_stmt);
+	void connection_finalized();
+
+	bool bind(const int64_t &p_index, const Variant &p_binding_value);
+	bool bind_all(const Array &p_values);
+	bool bind_named(const Dictionary &p_values);
+	void clear_bindings();
+
+	bool reset();
+	bool execute();
+	int64_t step();
+	TypedArray<Dictionary> fetch_all();
+	Dictionary get_row() const;
+	PackedStringArray get_column_names();
+	int64_t get_parameter_count() const;
+
+	void finalize();
+	bool is_valid() const;
+	int64_t get_status() const;
+
+	String get_error_message() const;
+};
+
+} //namespace godot
+
+VARIANT_ENUM_CAST(SQLiteStatement::StatementStatus);
+
+#endif // ! GDSQLITE_STATEMENT_H

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -7,6 +7,7 @@
 #include <godot_cpp/godot.hpp>
 
 #include "gdsqlite.hpp"
+#include "gdsqlite_statement.hpp"
 
 using namespace godot;
 
@@ -15,6 +16,7 @@ void initialize_sqlite_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
+	GDREGISTER_CLASS(SQLiteStatement);
 	GDREGISTER_CLASS(SQLite);
 }
 


### PR DESCRIPTION
Support for prepared statements.

# API

New API exported `SQLiteStatement` class.

```gdscript
# Prepare a statement
var statement = db.prepare("SELECT id, name FROM company WHERE age >= :min_age ORDER BY id;")

# Bind SQL Parameters
statement.bind_named({"min_age": 30})

# Execute the statement
var rows = statement.fetch_all()

# Reuse the prepared statement
statement.reset() # Resets/clears the cursor
statement.clear_bindings() # Clears SQL parameter bindings

if not statement.bind_named({"min_age": 20}):
	print("Select re-bind failed: " + statement.get_error_message())
else:
	var rows: Array = []
	var step_result: int = statement.step()
	while step_result == SQLite.SQLITE_ROW:
		rows.append(statement.get_row())
		step_result = statement.step()
	if step_result != SQLite.SQLITE_DONE:
		print("Prepared step failed (" + str(step_result) + "): " + statement.get_error_message())
	print("Prepared step rows (age >= 20): " + str(rows))

# Free the statement
statement.finalize()
```

Please note that you really do want to call `finalize()` to avoid memory leaks. That said, the connection itself also tracks the prepared statements, so if you clean up the connection it will clean-up any left over prepared statements.

# Tests

Tests have been updated to include code similar to the above.

# Docs

XML docs have been updated too.

# AI Disclosure

LLMs were used during development. If that's an concern for this repo, do not merge.