### PR TITLE
Add signals for row inserted, updated, deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,20 @@ Additionally, a video tutorial by [Mitch McCollum (finepointcgi)](https://github
     db.load_extension("res://addons/godot-sqlite/extensions/spellfix.dll", "sqlite3_spellfix_init")
     ```
 
+## Signals
+
+- **row_deleted(** String table_name, int rowid **)**
+
+    Emitted when a row is deleted.
+
+- **row_inserted(** String table_name, int rowid **)**
+
+    Emitted when a row is inserted.
+
+- **row_updated(** String table_name, int rowid **)**
+
+    Emitted when a row is updated.
+
 ## Frequently Asked Questions (FAQ)
 
 ### 1. My query fails and returns syntax errors, what should I do?

--- a/doc_classes/SQLite.xml
+++ b/doc_classes/SQLite.xml
@@ -295,6 +295,21 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="row_deleted">
+			<description>
+				Emitted when a row is deleted.
+			</description>
+		</signal>
+		<signal name="row_inserted">
+			<description>
+				Emitted when a row is inserted.
+			</description>
+		</signal>
+		<signal name="row_updated">
+			<description>
+				Emitted when a row is updated.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="QUIET" value="0">

--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -111,6 +111,26 @@ void SQLite::_bind_methods() {
 	BIND_CONSTANT(SQLITE_ROW);
 	BIND_CONSTANT(SQLITE_DONE);
 	/* end-of-error-codes */
+
+	// Signals.
+	ADD_SIGNAL(MethodInfo("row_inserted", PropertyInfo(Variant::STRING, "table_name"), PropertyInfo(Variant::INT, "rowid")));
+	ADD_SIGNAL(MethodInfo("row_updated", PropertyInfo(Variant::STRING, "table_name"), PropertyInfo(Variant::INT, "rowid")));
+	ADD_SIGNAL(MethodInfo("row_deleted", PropertyInfo(Variant::STRING, "table_name"), PropertyInfo(Variant::INT, "rowid")));
+}
+
+void update_hook_callback(void* db_ref, int notif_type, char const* db_name, char const* table_name, sqlite3_int64 row_id) {
+	SQLite *sqlite = (SQLite *)db_ref;
+	switch (notif_type) {
+		case SQLITE_INSERT:
+			sqlite->emit_signal("row_inserted", String(table_name), row_id);
+			break;
+		case SQLITE_UPDATE:
+			sqlite->emit_signal("row_updated", String(table_name), row_id);
+			break;
+		case SQLITE_DELETE:
+			sqlite->emit_signal("row_deleted", String(table_name), row_id);
+			break;
+	}
 }
 
 SQLite::SQLite() {
@@ -181,6 +201,9 @@ bool SQLite::open_db() {
 			return false;
 		}
 	}
+
+	/* Connect data change notification callbacks to signals. */
+	sqlite3_update_hook(db, update_hook_callback, this);
 
 	return true;
 }


### PR DESCRIPTION
This PR adds signals connected to sqlite's [update hook notifications](https://sqlite.org/c3ref/update_hook.html).

I had needed this for my own project, and I figured I would upstream this in case anyone else needed this functionality, as there really isn't a way to do this otherwise.

Let me know if you would like this gated behind a flag, or to change the signals or whatnot.